### PR TITLE
Ignore nonexistance of agetty

### DIFF
--- a/sbin/issue-generator.in
+++ b/sbin/issue-generator.in
@@ -108,4 +108,4 @@ done
 
 find_files
 generate_issue > ${PREFIX}/run/issue
-/usr/sbin/agetty --reload > /dev/null || :
+[ -x /usr/sbin/agetty ] && /usr/sbin/agetty --reload > /dev/null || :


### PR DESCRIPTION
Fixes this error during installation of *-release:

    /usr/sbin/issue-generator: line 111: /usr/sbin/agetty: No such file or directory