### PR TITLE
Extend NETWORK_INTERFACE_REGEX whitelist

### DIFF
--- a/udev/sysconfig.issue-generator
+++ b/udev/sysconfig.issue-generator
@@ -1,9 +1,9 @@
 ## Path:        System/Login
 ## Description: /etc/issue generator
 ## Type:        string
-## Default:     "^[be]"
+## Default:     "^[beqichw]"
 #
 # Defines a regex, for which network interfaces
 # /etc/issue should present the IP number
 #
-NETWORK_INTERFACE_REGEX="^[be]"
+NETWORK_INTERFACE_REGEX="^[beqichw]"


### PR DESCRIPTION
Also include interfaces on s390x and wireless ones (bsc#1169070).

Maybe `^[^dlv]` to explicitly exclude `dockerX`,`lo`/`virbrX`/`vnetX` makes more sense at this point?