### PR TITLE
Do not call agetty --reload (boo#1186178)

### DIFF
--- a/sbin/issue-generator.in
+++ b/sbin/issue-generator.in
@@ -145,6 +145,6 @@ else
 	RELOAD=0
     fi
 fi
-if [ ${RELOAD} -eq 1 ]; then
-    [ -x /usr/sbin/agetty ] && /usr/sbin/agetty --reload > /dev/null || :
+if [ ${RELOAD} -eq 1 ] && [ -e /run/agetty.reload ]; then
+    > /run/agetty.reload
 fi


### PR DESCRIPTION
Since issue-generator runs before the actual agettys, /run/agetty.reload
would be created with wrong SELinux context. So instead of calling
agetty --reload, touch /run/agetty.reload if it exists.